### PR TITLE
Deprecate cbo:Document

### DIFF
--- a/src/cbo.owl
+++ b/src/cbo.owl
@@ -21,13 +21,13 @@
     <owl:Ontology rdf:about="http://comicmeta.org/cbo/">
         <owl:versionIRI rdf:resource="http://comicmeta.org/cbo/"/>
         <dc:creator rdf:resource="https://sean.petiya.com/#me"/>
-        <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An RDF metadata vocabulary for describing comic books and comic book collections.</dc:description>
+        <dc:description>An RDF metadata vocabulary for describing comic books and comic book collections.</dc:description>
         <dc:title xml:lang="en">Comic Book Ontology</dc:title>
         <dcterms:license rdf:resource="http://creativecommons.org/licenses/by/4.0"/>
-        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2022-06-28</dcterms:modified>
-        <vann:preferredNamespacePrefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cbo</vann:preferredNamespacePrefix>
-        <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://comicmeta.org/cbo/</vann:preferredNamespaceUri>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0.15.4</owl:versionInfo>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-03-06</dcterms:modified>
+        <vann:preferredNamespacePrefix>cbo</vann:preferredNamespacePrefix>
+        <vann:preferredNamespaceUri>http://comicmeta.org/cbo/</vann:preferredNamespaceUri>
+        <owl:versionInfo>0.16.0</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -102,7 +102,7 @@
     <!-- http://purl.org/dc/terms/created -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/created">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dcterms:created</rdfs:label>
+        <rdfs:label>dcterms:created</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -110,7 +110,7 @@
     <!-- http://purl.org/dc/terms/issued -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/issued">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dcterms:issued</rdfs:label>
+        <rdfs:label>dcterms:issued</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -124,7 +124,7 @@
     <!-- http://purl.org/dc/terms/modified -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/modified">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dcterms:modified</rdfs:label>
+        <rdfs:label>dcterms:modified</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -132,7 +132,7 @@
     <!-- http://purl.org/vocab/vann/preferredNamespacePrefix -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/vocab/vann/preferredNamespacePrefix">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vann:preferredNamespacePrefix</qlabel>
+        <qlabel>vann:preferredNamespacePrefix</qlabel>
         <vann:preferredNamespacePrefix xml:lang="en">The preferred namespace prefix to use when using terms from this vocabulary in an XML document.</vann:preferredNamespacePrefix>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/vocab/vann"/>
     </owl:AnnotationProperty>
@@ -152,7 +152,7 @@
     <!-- http://www.w3.org/2000/01/rdf-schema#label -->
 
     <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rdfs:label</qlabel>
+        <qlabel>rdfs:label</qlabel>
     </rdf:Description>
     
 
@@ -205,7 +205,7 @@
         <rdfs:range rdf:resource="http://schema.org/CreativeWork"/>
         <rdfs:comment xml:lang="en">Links a comic to an adaptation.</rdfs:comment>
         <rdfs:label xml:lang="en">adaptation</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -218,7 +218,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:comment xml:lang="en">Links a work to the comic work it is an adaptation of.</rdfs:comment>
         <rdfs:label xml:lang="en">adaptation of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -230,7 +230,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Thing"/>
         <rdfs:comment xml:lang="en">Describes the appearance of a comic universe element within a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">appearance</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -243,7 +243,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates an artist with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">artist</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -256,7 +256,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Artwork"/>
         <rdfs:comment xml:lang="en">Links a comic page to its original artwork.</rdfs:comment>
         <rdfs:label xml:lang="en">artwork</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -268,7 +268,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Page"/>
         <rdfs:comment xml:lang="en">Links orginal comic artwork to a page.</rdfs:comment>
         <rdfs:label xml:lang="en">artwork of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -278,7 +278,7 @@
     <owl:ObjectProperty rdf:about="http://comicmeta.org/cbo/artworkType">
         <rdfs:comment xml:lang="en">Describes the artwork type of one or more pages of comic art.</rdfs:comment>
         <rdfs:label xml:lang="en">artwork type</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -290,7 +290,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/PhysicalAttribute"/>
         <rdfs:comment xml:lang="en">Describes a physical attribute of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">attribute</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -304,7 +304,7 @@
         <dc:description xml:lang="en">Having this property implies that the comic is bagged.</dc:description>
         <rdfs:comment xml:lang="en">Describes the bag in which a comic is contained.</rdfs:comment>
         <rdfs:label xml:lang="en">bagged</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -329,7 +329,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Binding"/>
         <rdfs:comment xml:lang="en">Describes the binding of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">binding</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -343,7 +343,7 @@
         <dc:description xml:lang="en">Having this property implies that the comic is boarded.</dc:description>
         <rdfs:comment xml:lang="en">Describes the backing board of a comic.</rdfs:comment>
         <rdfs:label xml:lang="en">boarded</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -356,7 +356,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Box"/>
         <rdfs:comment xml:lang="en">Associates a box with a comic book collection.</rdfs:comment>
         <rdfs:label xml:lang="en">box</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -369,7 +369,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Character"/>
         <rdfs:comment xml:lang="en">Describes a cameo appearance by a comic character in a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">cameo</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -382,7 +382,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Caption"/>
         <rdfs:comment xml:lang="en">Links a panel to a caption.</rdfs:comment>
         <rdfs:label xml:lang="en">caption</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -395,7 +395,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Character"/>
         <rdfs:comment xml:lang="en">Describes the appearance of a comic character in a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">character</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -409,7 +409,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic work to another work that reprints it as part of a comprehensive collection of reprinted material.</rdfs:comment>
         <rdfs:label xml:lang="en">collected in</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -421,7 +421,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Collection"/>
         <rdfs:comment xml:lang="en">Links a collector to a collection.</rdfs:comment>
         <rdfs:label xml:lang="en">collection</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -434,8 +434,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to another work that reprints it as part of a comprehensive collection of reprinted material.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">collects</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>collects</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -448,7 +448,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates a colorist with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">colorist</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -472,7 +472,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Condition"/>
         <rdfs:comment xml:lang="en">Describes the physical condition of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">condition</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -485,7 +485,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Copy"/>
         <rdfs:comment xml:lang="en">Describes the contents of a box of comics.</rdfs:comment>
         <rdfs:label xml:lang="en">contains</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -498,7 +498,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates a contributor with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">contributor</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -511,7 +511,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Copy"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a specific copy.</rdfs:comment>
         <rdfs:label xml:lang="en">copy</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -523,7 +523,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a specific copy to a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">copy of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -535,7 +535,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/State"/>
         <rdfs:comment xml:lang="en">Describes the physical state of a copy of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">copy state</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -547,7 +547,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:comment xml:lang="en">Links a comic series to its country of origin.</rdfs:comment>
         <rdfs:label xml:lang="en">country</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -559,7 +559,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Page"/>
         <rdfs:comment xml:lang="en">Describes the cover art of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">cover art</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -586,7 +586,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Creator"/>
         <rdfs:comment xml:lang="en">Associates a creator with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">creator</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -598,7 +598,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Distributor"/>
         <rdfs:comment xml:lang="en">Links a comic series to a distributor.</rdfs:comment>
         <rdfs:label xml:lang="en">distributed by</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -610,7 +610,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Edition"/>
         <rdfs:comment xml:lang="en">Describes the edition of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">edition</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -623,7 +623,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates an editor with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">editor</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -649,7 +649,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Event"/>
         <rdfs:comment xml:lang="en">Describes a comic universe event depicted in a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">event</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -661,7 +661,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Format"/>
         <rdfs:comment xml:lang="en">Describes the format of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">format</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -673,7 +673,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Genre"/>
         <rdfs:comment xml:lang="en">Describes the genre of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">genre</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -685,7 +685,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Grade"/>
         <rdfs:comment xml:lang="en">Describes the grade assigned to a comic item by a guarantor.</rdfs:comment>
         <rdfs:label xml:lang="en">grade</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -697,7 +697,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Guarantor"/>
         <rdfs:comment xml:lang="en">Links a graded copy of a comic issue to a guarantor.</rdfs:comment>
         <rdfs:label xml:lang="en">guaranteed by</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -710,7 +710,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Imprint"/>
         <rdfs:comment xml:lang="en">Associates a comic publisher with an imprint.</rdfs:comment>
         <rdfs:label xml:lang="en">imprint</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -722,7 +722,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Publisher"/>
         <rdfs:comment xml:lang="en">Associates an imprint with a comic publisher.</rdfs:comment>
         <rdfs:label xml:lang="en">imprint of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -734,7 +734,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Box"/>
         <rdfs:comment xml:lang="en">Links a comic item to a box.</rdfs:comment>
         <rdfs:label xml:lang="en">in box</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -747,7 +747,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates an inker with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">inker</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -761,7 +761,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a volume of comics to an issue.</rdfs:comment>
         <rdfs:label xml:lang="en">issue</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -774,7 +774,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Volume"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a volume.</rdfs:comment>
         <rdfs:label xml:lang="en">issue of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -788,7 +788,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Item"/>
         <rdfs:comment xml:lang="en">Links a comic book collection to an item.</rdfs:comment>
         <rdfs:label xml:lang="en">item</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -801,7 +801,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Collection"/>
         <rdfs:comment xml:lang="en">Links an item to a comic book collection.</rdfs:comment>
         <rdfs:label xml:lang="en">item of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -814,7 +814,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:comment xml:lang="en">Decribes the language of a comic series.</rdfs:comment>
         <rdfs:label xml:lang="en">language</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -827,7 +827,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates a letterer with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">letterer</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -839,7 +839,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Material"/>
         <rdfs:comment xml:lang="en">Describes the material of which a physical item is composed.</rdfs:comment>
         <rdfs:label xml:lang="en">material</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -852,7 +852,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Object"/>
         <rdfs:comment xml:lang="en">Describes the appearance of a comic object in a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">object</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -865,7 +865,7 @@
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <rdfs:comment xml:lang="en">Links an item or collection to the agent that owns it.</rdfs:comment>
         <rdfs:label xml:lang="en">owner</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -878,7 +878,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Item"/>
         <rdfs:comment xml:lang="en">Links an agent to an owned item or collection.</rdfs:comment>
         <rdfs:label xml:lang="en">owner of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -890,7 +890,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Page"/>
         <rdfs:comment xml:lang="en">Links a comic page to a document.</rdfs:comment>
         <rdfs:label xml:lang="en">page</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -902,7 +902,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/PageType"/>
         <rdfs:comment xml:lang="en">Describes the type of one or more comic pages.</rdfs:comment>
         <rdfs:label xml:lang="en">page type</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -915,7 +915,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Panel"/>
         <rdfs:comment xml:lang="en">Links a sequence to a comic panel.</rdfs:comment>
         <rdfs:label xml:lang="en">panel</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -928,7 +928,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Paper"/>
         <rdfs:comment xml:lang="en">Describes the paper stock of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">paper</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -941,7 +941,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates a penciller with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">penciller</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -952,7 +952,7 @@
         <rdfs:subPropertyOf rdf:resource="http://comicmeta.org/cbo/contributor"/>
         <rdfs:comment xml:lang="en">Associates a plotter with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">plotter</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -964,7 +964,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a preview or sample of that work.</rdfs:comment>
         <rdfs:label xml:lang="en">preview</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -976,7 +976,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Frequency"/>
         <rdfs:comment xml:lang="en">The publication frequency of a comic.</rdfs:comment>
         <rdfs:label xml:lang="en">publication frequency</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -989,7 +989,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Publisher"/>
         <rdfs:comment xml:lang="en">Links a publisher to a comic publication.</rdfs:comment>
         <rdfs:label xml:lang="en">publisher</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1001,7 +1001,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Quality"/>
         <rdfs:comment xml:lang="en">Describes a distinctive quality of an object.</rdfs:comment>
         <rdfs:label xml:lang="en">quality</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1013,7 +1013,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:comment xml:lang="en">The rating of a comics publication.</rdfs:comment>
         <rdfs:label xml:lang="en">rating</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1024,8 +1024,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:comment xml:lang="en">Links a comic to a related object.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">related</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>related</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1039,7 +1039,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a work that reprints it.</rdfs:comment>
         <rdfs:label xml:lang="en">reprinted in</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1052,7 +1052,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic to the original work it reprints.</rdfs:comment>
         <rdfs:label xml:lang="en">reprints</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1064,7 +1064,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Role"/>
         <rdfs:comment xml:lang="en">Describes the role of a contributor in the creation of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">role</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1076,7 +1076,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Sequence"/>
         <rdfs:comment xml:lang="en">Links a sequence to a page.</rdfs:comment>
         <rdfs:label xml:lang="en">sequence</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1090,7 +1090,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Series"/>
         <rdfs:comment xml:lang="en">Links a comic to a series.</rdfs:comment>
         <rdfs:label xml:lang="en">series</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1103,7 +1103,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Publication"/>
         <rdfs:comment xml:lang="en">Links a series to a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">series of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1116,7 +1116,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/State"/>
         <rdfs:comment xml:lang="en">Describes the physical state of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">state</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1129,7 +1129,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Story"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a story.</rdfs:comment>
         <rdfs:label xml:lang="en">story</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1142,8 +1142,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Story"/>
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Story"/>
         <rdfs:comment xml:lang="en">Links a comic story to a story arc.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">story arc</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>story arc</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1168,7 +1168,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:comment xml:lang="en">The subject of a comic story.</rdfs:comment>
         <rdfs:label xml:lang="en">subject</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1181,7 +1181,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Team"/>
         <rdfs:comment xml:lang="en">Describes the appearance of a team of comic characters in a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">team</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1195,7 +1195,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to a translation.</rdfs:comment>
         <rdfs:label xml:lang="en">translation</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1208,7 +1208,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to the issue it is a translation of.</rdfs:comment>
         <rdfs:label xml:lang="en">translation of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1220,7 +1220,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/ComicUniverse"/>
         <rdfs:comment xml:lang="en">Links a thing to a comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">universe</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1259,7 +1259,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:comment xml:lang="en">Links a comic issue to the issue it is a variant of.</rdfs:comment>
         <rdfs:label xml:lang="en">variant of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1273,7 +1273,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Volume"/>
         <rdfs:comment xml:lang="en">Links a series to a comic volume.</rdfs:comment>
         <rdfs:label xml:lang="en">volume</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1286,7 +1286,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Series"/>
         <rdfs:comment xml:lang="en">Links a volume to a comic series.</rdfs:comment>
         <rdfs:label xml:lang="en">volume of</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1299,7 +1299,7 @@
         <rdfs:range rdf:resource="http://comicmeta.org/cbo/Contributor"/>
         <rdfs:comment xml:lang="en">Associates a writer with a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">writer</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:ObjectProperty>
     
 
@@ -1391,7 +1391,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">An alternative title for any comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">alternative title</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1402,8 +1402,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Issue"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">Comics Code Authority (CCA) approved.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCA</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>CCA</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1416,7 +1416,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The certification number assigned to a graded copy of a comic by a guarantor.</rdfs:comment>
         <rdfs:label xml:lang="en">certification number</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1429,7 +1429,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The copyright date of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">copyright date</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1442,7 +1442,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The cover date of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">cover date</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1455,7 +1455,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The cover price of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">coverPrice</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1468,7 +1468,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">A Diamond Comic Distributors code.</rdfs:comment>
         <rdfs:label xml:lang="en">Diamond code</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1480,8 +1480,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Publication"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The distributor code associated with a comics publication.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distributor code</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>distributor code</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1494,7 +1494,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The date a comic ended publication.</rdfs:comment>
         <rdfs:label xml:lang="en">end year</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1519,7 +1519,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The name of a comic imprint.</rdfs:comment>
         <rdfs:label xml:lang="en">imprint name</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1531,7 +1531,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The publication frequency of a comic as printed in the indicia of an issue.</rdfs:comment>
         <rdfs:label xml:lang="en">indicia frequency</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1543,7 +1543,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The publisher name as printed in the indicia of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">indicia publisher</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1553,8 +1553,8 @@
     <owl:DatatypeProperty rdf:about="http://comicmeta.org/cbo/isbn">
         <rdfs:subPropertyOf rdf:resource="http://schema.org/isbn"/>
         <rdfs:comment xml:lang="en">The ISBN of a comic publication.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>ISBN</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1579,7 +1579,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The number of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">issueNumber</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1602,8 +1602,8 @@
     <owl:DatatypeProperty rdf:about="http://comicmeta.org/cbo/note">
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">A note.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">note</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>note</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1616,7 +1616,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The date of availability of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">on-sale date</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1630,7 +1630,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The number of pages in a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">page count</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1651,7 +1651,7 @@
     <owl:DatatypeProperty rdf:about="http://comicmeta.org/cbo/price">
         <rdfs:comment xml:lang="en">A general price.</rdfs:comment>
         <rdfs:label xml:lang="en">price</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1664,7 +1664,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The numerical print run of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">printing</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1677,7 +1677,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The date a comic issue was published.</rdfs:comment>
         <rdfs:label xml:lang="en">publication date</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1690,7 +1690,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The name of a comic publisher.</rdfs:comment>
         <rdfs:label xml:lang="en">publisher name</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1703,7 +1703,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The purchase price of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">purchase price</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1716,7 +1716,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The sale price of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">sale price</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1729,7 +1729,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The title of a comic series.</rdfs:comment>
         <rdfs:label xml:lang="en">series title</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1741,8 +1741,8 @@
         <rdfs:domain rdf:resource="http://comicmeta.org/cbo/Series"/>
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The year a comic series began publication.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">series year</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>series year</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1755,7 +1755,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The date a comic began publication.</rdfs:comment>
         <rdfs:label xml:lang="en">start year</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1768,7 +1768,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The title of a comic story.</rdfs:comment>
         <rdfs:label xml:lang="en">story title</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1792,7 +1792,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">Describes the tracking or numbering between comic series.</rdfs:comment>
         <rdfs:label xml:lang="en">tracking</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1805,7 +1805,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The UPC of a comic publication.</rdfs:comment>
         <rdfs:label xml:lang="en">UPC</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1817,7 +1817,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The estimated value of a comic item.</rdfs:comment>
         <rdfs:label xml:lang="en">value</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1830,7 +1830,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">Any variance to the regular manifestation of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">variance</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1843,7 +1843,7 @@
         <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
         <rdfs:comment xml:lang="en">The unique identifier of a comic volume.</rdfs:comment>
         <rdfs:label xml:lang="en">volumeNumber</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:DatatypeProperty>
     
 
@@ -1978,8 +1978,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Agent">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Thing"/>
         <rdfs:comment xml:lang="en">A person, organization, or intelligence in a comic universe.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Agent</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Agent</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -1991,7 +1991,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/IndividualProduct"/>
         <rdfs:comment xml:lang="en">Original comic artwork.</rdfs:comment>
         <rdfs:label xml:lang="en">Artwork</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2002,8 +2002,8 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Sequence"/>
         <rdfs:comment xml:lang="en">A word balloon containing dialogue or thought.</rdfs:comment>
         <rdfs:label xml:lang="en">Balloon</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.balloon</rdfs:seeAlso>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:seeAlso>http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.balloon</rdfs:seeAlso>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2014,7 +2014,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Material"/>
         <rdfs:comment xml:lang="en">A binding method or material used to bind the pages of a comic.</rdfs:comment>
         <rdfs:label xml:lang="en">Binding</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2025,7 +2025,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Container"/>
         <rdfs:comment xml:lang="en">A box that contains comic books.</rdfs:comment>
         <rdfs:label xml:lang="en">Box</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2047,8 +2047,8 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Sequence"/>
         <rdfs:comment xml:lang="en">A caption containing narration.</rdfs:comment>
         <rdfs:label xml:lang="en">Caption</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.caption</rdfs:seeAlso>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:seeAlso>http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.caption</rdfs:seeAlso>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2059,7 +2059,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Agent"/>
         <rdfs:comment xml:lang="en">A comic character.</rdfs:comment>
         <rdfs:label xml:lang="en">Character</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2070,7 +2070,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/Collection"/>
         <rdfs:comment xml:lang="en">A collection of comic books and related resources.</rdfs:comment>
         <rdfs:label xml:lang="en">Collection</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2081,7 +2081,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Person"/>
         <rdfs:comment xml:lang="en">A comic book collector.</rdfs:comment>
         <rdfs:label xml:lang="en">Collector</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2092,7 +2092,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/CreativeWork"/>
         <rdfs:comment xml:lang="en">A visual and literary work of sequential art.</rdfs:comment>
         <rdfs:label xml:lang="en">Comic</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">testing</vs:term_status>
+        <vs:term_status>testing</vs:term_status>
     </owl:Class>
     
 
@@ -2103,7 +2103,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A period of comic book history.</rdfs:comment>
         <rdfs:label xml:lang="en">Comic Age</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2114,7 +2114,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/CreativeWork"/>
         <rdfs:comment xml:lang="en">A comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">Comic Universe</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2125,7 +2125,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/PhysicalAttribute"/>
         <rdfs:comment xml:lang="en">A physical condition describing an object.</rdfs:comment>
         <rdfs:label xml:lang="en">Condition</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2136,7 +2136,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/PhysicalObject"/>
         <rdfs:comment xml:lang="en">An object containing comic books.</rdfs:comment>
         <rdfs:label xml:lang="en">Container</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2147,7 +2147,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Person"/>
         <rdfs:comment xml:lang="en">An agent contributing to the creation of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">Contributor</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2160,7 +2160,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/IndividualProduct"/>
         <rdfs:comment xml:lang="en">A copy of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">Copy</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2171,7 +2171,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Object"/>
         <rdfs:comment xml:lang="en">A comic character&apos;s costume.</rdfs:comment>
         <rdfs:label xml:lang="en">Costume</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2182,7 +2182,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Person"/>
         <rdfs:comment xml:lang="en">An agent primarily responsible for the creation of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">Creator</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2192,8 +2192,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Distributor">
         <rdfs:subClassOf rdf:resource="http://schema.org/Organization"/>
         <rdfs:comment xml:lang="en">An agent responsible for the distribution of a comic publication.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Distributor</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Distributor</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2204,7 +2204,8 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:comment xml:lang="en">A document composed of the pages in a comics publication.</rdfs:comment>
         <rdfs:label xml:lang="en">Document</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <vs:term_status>deprecated</vs:term_status>
     </owl:Class>
     
 
@@ -2215,7 +2216,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">An edition of a comic issue.</rdfs:comment>
         <rdfs:label xml:lang="en">Edition</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2226,7 +2227,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Thing"/>
         <rdfs:comment xml:lang="en">An event in a comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">Event</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2237,7 +2238,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A format in which a comic is embodied.</rdfs:comment>
         <rdfs:label xml:lang="en">Format</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2248,7 +2249,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A frequency with which a comic is published.</rdfs:comment>
         <rdfs:label xml:lang="en">Frequency</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2259,7 +2260,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A comics genre.</rdfs:comment>
         <rdfs:label xml:lang="en">Genre</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2270,7 +2271,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A grade assigned to a comic item that represents a summary of its condition.</rdfs:comment>
         <rdfs:label xml:lang="en">Grade</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2281,7 +2282,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Organization"/>
         <rdfs:comment xml:lang="en">An organization that guarantees the stated condition of a comic book.</rdfs:comment>
         <rdfs:label xml:lang="en">Guarantor</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2292,7 +2293,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Publisher"/>
         <rdfs:comment xml:lang="en">An imprint or tradename of a comic publisher.</rdfs:comment>
         <rdfs:label xml:lang="en">Imprint</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2306,7 +2307,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/PublicationIssue"/>
         <rdfs:comment xml:lang="en">An issue of a comic publication.</rdfs:comment>
         <rdfs:label xml:lang="en">Issue</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2315,8 +2316,8 @@
 
     <owl:Class rdf:about="http://comicmeta.org/cbo/Item">
         <rdfs:comment xml:lang="en">A physical or digital item.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Item</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Item</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2326,8 +2327,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Library">
         <rdfs:subClassOf rdf:resource="http://schema.org/Organization"/>
         <rdfs:comment xml:lang="en">A physical or digital library containing a collection of comic resources.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Library</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Library</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2338,7 +2339,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Thing"/>
         <rdfs:comment xml:lang="en">A location in a comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">Location</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2348,8 +2349,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Material">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/PhysicalAttribute"/>
         <rdfs:comment xml:lang="en">A material or medium of which an object is composed.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Material</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Material</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2360,7 +2361,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Organization"/>
         <rdfs:comment xml:lang="en">A physical or digital museum exhibiting a collection of comic resources.</rdfs:comment>
         <rdfs:label xml:lang="en">Museum</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2371,7 +2372,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Thing"/>
         <rdfs:comment xml:lang="en">An object in a comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">Object</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2379,10 +2380,10 @@
     <!-- http://comicmeta.org/cbo/Page -->
 
     <owl:Class rdf:about="http://comicmeta.org/cbo/Page">
-        <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Document"/>
-        <rdfs:comment xml:lang="en">One or more pages in a comics document.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Sequence"/>
+        <rdfs:comment xml:lang="en">A page in a comics sequence.</rdfs:comment>
         <rdfs:label xml:lang="en">Page</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2393,7 +2394,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A type of page appearing in a comic document.</rdfs:comment>
         <rdfs:label xml:lang="en">Page Type</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2404,8 +2405,8 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Sequence"/>
         <rdfs:comment xml:lang="en">A visual frame containing part of a sequence.</rdfs:comment>
         <rdfs:label xml:lang="en">Panel</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.panel</rdfs:seeAlso>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:seeAlso>http://dcl.slis.indiana.edu/cbml/schema/cbml.html#TEI.panel</rdfs:seeAlso>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2416,7 +2417,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Material"/>
         <rdfs:comment xml:lang="en">A paper stock on which a comic is printed.</rdfs:comment>
         <rdfs:label xml:lang="en">Paper</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2427,7 +2428,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Collection"/>
         <rdfs:comment xml:lang="en">An exceptional original owner collection of high quality, vintage comic books often containing copies that are considered exemplars of key issues.</rdfs:comment>
         <rdfs:label xml:lang="en">Pedigree</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2437,7 +2438,7 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/PhysicalAttribute">
         <rdfs:comment xml:lang="en">An physical attribute or property of an item.</rdfs:comment>
         <rdfs:label xml:lang="en">Attribute</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2448,7 +2449,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Location"/>
         <rdfs:comment xml:lang="en">A planetary body in a comic universe.</rdfs:comment>
         <rdfs:label xml:lang="en">Planet</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2459,7 +2460,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Material"/>
         <rdfs:comment xml:lang="en">A plastic of which a supply item is composed.</rdfs:comment>
         <rdfs:label xml:lang="en">Plastic</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2470,7 +2471,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:comment xml:lang="en">A comics publication.</rdfs:comment>
         <rdfs:label xml:lang="en">Publication</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2481,7 +2482,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Organization"/>
         <rdfs:comment xml:lang="en">An agent responsible for the publication of a comic.</rdfs:comment>
         <rdfs:label xml:lang="en">Publisher</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2491,8 +2492,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Quality">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/PhysicalAttribute"/>
         <rdfs:comment xml:lang="en">A distinctive quality belonging to an object.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Quality</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Quality</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2503,7 +2504,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Intangible"/>
         <rdfs:comment xml:lang="en">A creative role in the production of a comic work.</rdfs:comment>
         <rdfs:label xml:lang="en">Role</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2514,7 +2515,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:comment xml:lang="en">A visual sequence of juxtaposed panels and pictorial elements.</rdfs:comment>
         <rdfs:label xml:lang="en">Sequence</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2527,7 +2528,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/Periodical"/>
         <rdfs:comment xml:lang="en">A comic publication containing one or more volumes and issues.</rdfs:comment>
         <rdfs:label xml:lang="en">Series</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2538,7 +2539,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/PhysicalAttribute"/>
         <rdfs:comment xml:lang="en">A physical state describing an object.</rdfs:comment>
         <rdfs:label xml:lang="en">State</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2550,7 +2551,7 @@
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Comic"/>
         <rdfs:comment xml:lang="en">A comic story.</rdfs:comment>
         <rdfs:label xml:lang="en">Story</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2560,8 +2561,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Team">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Agent"/>
         <rdfs:comment xml:lang="en">A group of comic characters.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Team</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Team</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2571,8 +2572,8 @@
     <owl:Class rdf:about="http://comicmeta.org/cbo/Thing">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/ComicUniverse"/>
         <rdfs:comment xml:lang="en">A thing in a comic universe.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thing</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:label>Thing</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2581,9 +2582,9 @@
 
     <owl:Class rdf:about="http://comicmeta.org/cbo/Vehicle">
         <rdfs:subClassOf rdf:resource="http://comicmeta.org/cbo/Object"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A vehicle in a comic universe.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vehicle</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <rdfs:comment>A vehicle in a comic universe.</rdfs:comment>
+        <rdfs:label>Vehicle</rdfs:label>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2595,7 +2596,7 @@
         <rdfs:subClassOf rdf:resource="http://schema.org/PublicationVolume"/>
         <rdfs:comment xml:lang="en">A single issue or group of issues published in a comic series.</rdfs:comment>
         <rdfs:label xml:lang="en">Volume</rdfs:label>
-        <vs:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</vs:term_status>
+        <vs:term_status>unstable</vs:term_status>
     </owl:Class>
     
 
@@ -2603,7 +2604,7 @@
     <!-- http://purl.org/dc/dcmitype/Collection -->
 
     <owl:Class rdf:about="http://purl.org/dc/dcmitype/Collection">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dctype:Collection</qlabel>
+        <qlabel>dctype:Collection</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype"/>
     </owl:Class>
     
@@ -2612,7 +2613,7 @@
     <!-- http://purl.org/dc/dcmitype/PhysicalObject -->
 
     <owl:Class rdf:about="http://purl.org/dc/dcmitype/PhysicalObject">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dctype:PhysicalObject</qlabel>
+        <qlabel>dctype:PhysicalObject</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype"/>
     </owl:Class>
     
@@ -2667,7 +2668,7 @@
     <!-- http://schema.org/CreativeWork -->
 
     <owl:Class rdf:about="http://schema.org/CreativeWork">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:CreativeWork</qlabel>
+        <qlabel>schema:CreativeWork</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2677,7 +2678,7 @@
 
     <owl:Class rdf:about="http://schema.org/IndividualProduct">
         <rdfs:subClassOf rdf:resource="http://schema.org/Product"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:IndividualProduct</qlabel>
+        <qlabel>schema:IndividualProduct</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2686,7 +2687,7 @@
     <!-- http://schema.org/Intangible -->
 
     <owl:Class rdf:about="http://schema.org/Intangible">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:Intangible</qlabel>
+        <qlabel>schema:Intangible</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2696,7 +2697,7 @@
 
     <owl:Class rdf:about="http://schema.org/Organization">
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:Organization</qlabel>
+        <qlabel>schema:Organization</qlabel>
         <rdfs:comment xml:lang="en">An organization.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
@@ -2707,7 +2708,7 @@
 
     <owl:Class rdf:about="http://schema.org/Periodical">
         <rdfs:subClassOf rdf:resource="http://schema.org/CreativeWork"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:Periodical</qlabel>
+        <qlabel>schema:Periodical</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2717,7 +2718,7 @@
 
     <owl:Class rdf:about="http://schema.org/Person">
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:Person</qlabel>
+        <qlabel>schema:Person</qlabel>
         <rdfs:comment xml:lang="en">A person.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
@@ -2727,7 +2728,7 @@
     <!-- http://schema.org/Product -->
 
     <owl:Class rdf:about="http://schema.org/Product">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:Product</qlabel>
+        <qlabel>schema:Product</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2737,7 +2738,7 @@
 
     <owl:Class rdf:about="http://schema.org/PublicationIssue">
         <rdfs:subClassOf rdf:resource="http://schema.org/CreativeWork"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:PublicationIssue</qlabel>
+        <qlabel>schema:PublicationIssue</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2747,7 +2748,7 @@
 
     <owl:Class rdf:about="http://schema.org/PublicationVolume">
         <rdfs:subClassOf rdf:resource="http://schema.org/CreativeWork"/>
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schema:PublicationVolume</qlabel>
+        <qlabel>schema:PublicationVolume</qlabel>
         <rdfs:isDefinedBy rdf:resource="http://schema.org"/>
     </owl:Class>
     
@@ -2773,7 +2774,7 @@
     <!-- http://xmlns.com/foaf/0.1/Agent -->
 
     <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Agent">
-        <qlabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">foaf:Agent</qlabel>
+        <qlabel>foaf:Agent</qlabel>
         <rdfs:comment xml:lang="en">An agent.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/terms"/>
     </owl:Class>
@@ -4044,11 +4045,11 @@
     <!-- https://sean.petiya.com/#me -->
 
     <owl:NamedIndividual rdf:about="https://sean.petiya.com/#me">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sean Petiya</rdfs:label>
+        <rdfs:label>Sean Petiya</rdfs:label>
     </owl:NamedIndividual>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
Deprecate cbo:Document. Update term_status, add owl:deprecated annotation, move cbo:Page to subclass of cbo:Sequence.